### PR TITLE
Search for macOS provided Tcl

### DIFF
--- a/trunk/configure.in
+++ b/trunk/configure.in
@@ -346,7 +346,8 @@ else
 	${BUILD_DIR}/../tcl8.3b*/unix \
 	${BUILD_DIR}/../tcl8.4.*/unix \
 	${BUILD_DIR}/../tcl8.5.*/unix \
-	/usr/share /usr/lib64 /usr/lib"
+	/usr/share /usr/lib64 /usr/lib \
+	/System/Library/Frameworks/Tcl.framework/Versions/8.5"
   for i in $dirs ; do
     if test -d "$i" -a -f "$i/tclConfig.sh"; then
 	TCL_LIB_DIR=`cd $i; pwd`


### PR DESCRIPTION
macOS provides Tcl 8.5, but not in a Linux expected location, so include the path to the macOS provided Tcl 8.5 in the set of paths to search for Tcl in.